### PR TITLE
Add issue templates

### DIFF
--- a/ISSUE_TEMPLATE/bug_report.md
+++ b/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug Report
+about: Is something not working as expected?
+title: ''
+labels: bug
+assignees: ''
+---
+
+<!--
+BEFORE SUBMITTING: 
+1) Please search to make sure this issue has not been opened already
+2) If this is a implementation question or trouble with your personal project, please post on StackExchange. This will get your question answered more quickly and make it easier for other devs to find the answer in the future.
+-->
+
+### Describe the bug
+A clear and concise description of what the bug is.
+
+### How to reproduce
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+### Expected behavior
+A clear description of what you expected to happen.
+
+### Logs and screenshots
+If applicable, add logs and/or screenshots to help explain your problem.
+
+### Software details
+ - OS and version: [e.g. OS X, Windows 11, Android 10]
+ - Application and version: [e.g. , myApp 1.2.3, Safari 6, Firefox 104]
+
+### Additional context
+Add any other context about the problem here.

--- a/ISSUE_TEMPLATE/feature_request.md
+++ b/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,27 @@
+---
+name: Feature request
+about: Propose an idea for new improvements/features
+title: ''
+labels: enhancement
+assignees: ''
+---
+
+<!--
+BEFORE SUBMITTING: 
+1) Please search to make sure this feature has not been requested already
+2) If it is about something that does not work as expected, please create a bug report instead.
+-->
+
+### Description
+
+Please describe what functionality is needed
+
+### Motivation
+
+Please describe why it is needed
+
+### Acceptance criteria
+
+Please describe the conditions which must be met for this issue to close
+
+### Additional information

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -18,7 +18,7 @@ _Put an `x` in the boxes that apply_
 _Put an `x` in the boxes that apply. You can also fill these out after creating the PR._
 
 _If you're unsure, don't hesitate to ask for help in a comment.
-This is simply a reminder of what reviewers are going to look._
+This is simply a reminder of what reviewers are going to look at._
 
 ### Always required:
 - [ ] Title of the PR is meaningful


### PR DESCRIPTION
## Description

**Related issue(s)**: LeastAuthority/it-ops#142

**Proposed change(s)**: Add default issue templates for bug report and feature request.

**Additional context**: These new templates should only be visible from repositories that were not yet providing any template for those type of issue (based on the name in the header).

## Types of changes
_Put an `x` in the boxes that apply_

- [ ] Documentation or cosmetic update (not impacting the code)
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
_Put an `x` in the boxes that apply. You can also fill these out after creating the PR._

_If you're unsure, don't hesitate to ask for help in a comment.
This is simply a reminder of what reviewers are going to look._

### Always required:
- [x] Title of the PR is meaningful
- [x] Description refers to an issue discussing the matter
- [x] PR is appropriately sized
### Only when relevant:
- [ ] Tests have been added for new functionalities
- [ ] Documentation has been updated accordingly
- [ ] Checks in place have passed
- [ ] Code coverage does not decrease

## Thank you!